### PR TITLE
pbourke's small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _*/
 /*.ipynb
 /*.json
 *.txt
+.python-version
+sammo-env/

--- a/sammo/base.py
+++ b/sammo/base.py
@@ -1,16 +1,9 @@
 import abc
 import copy
 import re
-import sys
 
-if sys.version_info < (3, 11):
-    from typing_extensions import Self
-else:
-    from typing import Self
-    
-from typing import Callable
+from beartype.typing import Callable, Self
 from frozendict import frozendict
-
 import pyglove as pg
 import pybars
 from tabulate import tabulate

--- a/sammo/base.py
+++ b/sammo/base.py
@@ -101,7 +101,10 @@ class Result:
             return [self.parent]
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(value={repr(self.value)[:100]}..., parent={self.parent.__class__.__name__})"
+        value_str = repr(self.value)
+        if len(value_str) > 100:
+            value_str = value_str[:100] + "..."
+        return f"{self.__class__.__name__}(value={value_str}, parent={self.parent.__class__.__name__})"
 
 
 class NonEmptyResult(Result):

--- a/sammo/components.py
+++ b/sammo/components.py
@@ -2,12 +2,11 @@ import asyncio
 import logging
 import math
 import warnings
-from typing import Callable
-from frozendict import frozendict
 
 import beartype
+from beartype.typing import Callable, Literal
+from frozendict import frozendict
 
-import typing
 import sammo.utils as utils
 from sammo.base import (
     Component,
@@ -53,7 +52,7 @@ class GenerateText(ScalarComponent):
         seed=0,
         randomness: float = 0,
         max_tokens=None,
-        on_error: typing.Literal["raise", "empty_result"] = "empty_result",
+        on_error: Literal["raise", "empty_result"] = "empty_result",
     ):
         super().__init__(child, name)
 
@@ -221,7 +220,7 @@ class Output(Component):
         self,
         child: Component,
         minibatch_size=1,
-        on_error: typing.Literal["raise", "empty_result", "backoff"] = "raise",
+        on_error: Literal["raise", "empty_result", "backoff"] = "raise",
     ):
         super().__init__(child)
         self.row_batch_size = minibatch_size
@@ -234,7 +233,7 @@ class Output(Component):
         data: DataTable | list | None = None,
         progress_callback: Callable | bool = True,
         priority: int = 0,
-        on_error: typing.Literal["raise", "empty_result", "backoff"] = "raise",
+        on_error: Literal["raise", "empty_result", "backoff"] = "raise",
     ) -> DataTable:
         """Synchronous version of `arun`."""
         return utils.sync(self.arun(runner, data, progress_callback, priority, on_error))
@@ -253,7 +252,7 @@ class Output(Component):
         data: DataTable | list | None = None,
         progress_callback: Callable | bool = True,
         priority: int = 0,
-        on_error: typing.Literal["raise", "empty_result", "backoff"] = "raise",
+        on_error: Literal["raise", "empty_result", "backoff"] = "raise",
     ):
         """
         Run the component asynchronously and return a DataTable with the results.

--- a/sammo/data.py
+++ b/sammo/data.py
@@ -46,8 +46,8 @@ class DataTable(pg.JSONConvertible):
         constants: dict | None = None,
         seed=42,
     ):
-        inputs = self._ensure_list(inputs)
-        outputs = self._ensure_list(outputs or [None] * len(inputs))
+        inputs = DataTable._ensure_list(inputs)
+        outputs = DataTable._ensure_list(outputs or [None] * len(inputs))
 
         if len(inputs) != len(outputs):
             raise ValueError(f"Input fields have {len(inputs)} rows, but output fields have {len(outputs)} rows.")
@@ -190,14 +190,14 @@ class DataTable(pg.JSONConvertible):
         :param max_col_width: Maximum width of each column. Defaults to 50.
         :param max_cell_length: Maximum characters in each cell. Defaults to 100.
         """
-        table_data = [{str(k): self._truncate(v, max_cell_length) for k, v in x.items()} for x in self.to_records()]
+        table_data = [{str(k): DataTable._truncate(v, max_cell_length) for k, v in x.items()} for x in self.to_records()]
         if table_data:
             table = tabulate.tabulate(
                 table_data[:max_rows], headers="keys", maxcolwidths=max_col_width, tablefmt="grid"
             )
         else:
             table = "<empty DataTable>"
-        return f"{table}\nConstants: {self._truncate(self.constants, max_col_width)}"
+        return f"{table}\nConstants: {DataTable._truncate(self.constants, max_col_width)}"
 
     def _to_explicit_idx(self, key: int | slice | list[int]):
         if isinstance(key, int):

--- a/sammo/data.py
+++ b/sammo/data.py
@@ -2,27 +2,19 @@
 DataTables are the primary data structure used in SAMMO.
 They are essentially a wrapper around a list of inputs and outputs (labels), with some additional functionality.
 """
-import collections
 import copy
 import hashlib
 import math
-import sys
+
+from beartype import beartype
+from beartype.typing import Callable, Iterator, Self
+import more_itertools
+import orjson
+import pyglove as pg
+import random
+import tabulate
 
 from sammo.utils import serialize_json
-
-if sys.version_info < (3, 11):
-    from typing_extensions import Self
-else:
-    from typing import Self
-
-from typing import Iterator, Callable
-
-import more_itertools
-import pyglove as pg
-import orjson
-import random
-from beartype import beartype
-import tabulate
 
 
 # monkey-patch to fix bug in tabulate with booleans and multline

--- a/sammo/data.py
+++ b/sammo/data.py
@@ -291,7 +291,7 @@ class Accessor:
 
         :param name: Name of the field.
         """
-        new_data = [self._safe_get(y, name) for y in self.raw_values]
+        new_data = [Accessor._safe_get(y, name) for y in self.raw_values]
         clone = copy.deepcopy(self._parent)
         clone._data[self._group] = new_data
         return clone

--- a/sammo/dataformatters.py
+++ b/sammo/dataformatters.py
@@ -5,10 +5,10 @@ get_extractor method that can be used to parse the LLM responses in this format.
 """
 import collections
 import json
-from typing import Sequence, Literal
 
-import xmltodict
+from beartype.typing import Sequence, Literal
 from frozendict import frozendict
+import xmltodict
 
 from sammo.base import Component, Runner
 from sammo.data import OutputAccessor

--- a/sammo/dataformatters.py
+++ b/sammo/dataformatters.py
@@ -55,7 +55,6 @@ class LongFormatData:
 
 
 class DataFormatter(Component):
-    DEFAULT_NAMES = {"input": "input", "gold_label": "output", "predicted_label": "predicted_output"}
     """
     A DataFormatter is a component that takes a DataTable or dict and formats it into a string.
 
@@ -66,6 +65,7 @@ class DataFormatter(Component):
         all inputs or output labels are grouped together.
     :param all_labels: A list of all possible labels, used by some formatters to determine the extractor.
     """
+    DEFAULT_NAMES = {"input": "input", "gold_label": "output", "predicted_label": "predicted_output"}
 
     def __init__(
         self,

--- a/sammo/extractors.py
+++ b/sammo/extractors.py
@@ -4,18 +4,19 @@ Common formats such as JSON, XML, or Markdown are supported and require no data 
 required, it should happen downstream of the extraction step.
 """
 import abc
+import ast
 import fractions
 import json
 import logging
 import re
-import typing
-import ast
+
+from beartype.typing import Literal
 from frozendict import frozendict
 import jsonpath_ng
-import xmltodict
-import yaml
 from markdown_it import MarkdownIt
 from markdown_it.tree import SyntaxTreeNode
+import xmltodict
+import yaml
 
 from sammo.base import ListComponent, Component, LLMResult, EmptyResult, ParseResult, Runner, NonEmptyResult
 
@@ -30,7 +31,7 @@ class Extractor(ListComponent):
     :param flatten: Whether to flatten the output.
     """
 
-    def __init__(self, child: Component, on_error: typing.Literal["raise", "empty_result"] = "raise", flatten=True):
+    def __init__(self, child: Component, on_error: Literal["raise", "empty_result"] = "raise", flatten=True):
         super().__init__(child)
         self._on_error = on_error
         self.dependencies = [self._child]
@@ -123,7 +124,7 @@ class LambdaExtractor(Extractor):
         self,
         child: Component,
         lambda_src_code: str,
-        on_error: typing.Literal["raise", "empty_result"] = "raise",
+        on_error: Literal["raise", "empty_result"] = "raise",
         flatten=True,
     ):
         super().__init__(child, on_error, flatten)
@@ -154,7 +155,7 @@ class ParseJSON(Extractor):
     def __init__(
         self,
         child: Component,
-        parse_fragments: typing.Literal["all", "first", "whole"] = "all",
+        parse_fragments: Literal["all", "first", "whole"] = "all",
         lowercase_fieldnames: bool = True,
         on_error="raise",
     ):
@@ -298,7 +299,7 @@ class ParseXML(Extractor):
     def __init__(
         self,
         child: Component,
-        parse_fragments: typing.Literal["all", "first", "none"] = "first",
+        parse_fragments: Literal["all", "first", "none"] = "first",
         ignore_fragments_with_tags=tuple(),
         on_error: str = "raise",
         use_attributes_marker=False,
@@ -391,8 +392,8 @@ class ToNum(Extractor):
     def __init__(
         self,
         child: Component,
-        on_error: typing.Literal["raise", "empty_result"] = "raise",
-        dtype: typing.Literal["fraction", "int", "float"] = "float",
+        on_error: Literal["raise", "empty_result"] = "raise",
+        dtype: Literal["fraction", "int", "float"] = "float",
         factor: float = 1,
         offset: float = 0,
     ):

--- a/sammo/instructions.py
+++ b/sammo/instructions.py
@@ -1,17 +1,12 @@
 import json
-import re
-import typing
-from json import JSONDecodeError
 
+from beartype.typing import Literal
 from frozendict import frozendict
 
 from sammo.base import Component, LLMResult, Runner, TextResult, ScalarComponent
 from sammo.components import GenerateText
 from sammo.data import DataTable
 from sammo.dataformatters import DataFormatter
-from sammo.extractors import ParseJSON, MarkdownParser, ParseXML
-
-import pyglove as pg
 
 
 class Section(Component):
@@ -54,7 +49,7 @@ class MetaPrompt(Component):
     def __init__(
         self,
         structure: list[Paragraph | Section],
-        render_as: typing.Literal["raw", "json", "xml", "markdown", "markdown-alt"] = "markdown",
+        render_as: Literal["raw", "json", "xml", "markdown", "markdown-alt"] = "markdown",
         data_formatter: DataFormatter | None = None,
         name: str | None = None,
         seed: int = 0
@@ -71,7 +66,7 @@ class MetaPrompt(Component):
         filled_out_structure = [await child(runner, context, dynamic_context) for child in self._structure]
         return TextResult(self._render(filled_out_structure))
 
-    def with_extractor(self, on_error: typing.Literal["raise", "empty_result"] = "raise"):
+    def with_extractor(self, on_error: Literal["raise", "empty_result"] = "raise"):
         if self._data_formatter is not None:
             return self._data_formatter.get_extractor(GenerateText(self), on_error=on_error)
         else:

--- a/sammo/mutators.py
+++ b/sammo/mutators.py
@@ -3,10 +3,10 @@ import asyncio
 import collections
 import logging
 import random
-import textwrap
-import typing
-from typing import Callable, Any
 import re
+import textwrap
+
+from beartype.typing import Callable, Literal
 import numpy as np
 import pyglove as pg
 import spacy
@@ -859,7 +859,7 @@ class StopwordsCompressor(Component):
 
     def __init__(
         self,
-        filter_stopwords: typing.Literal["reuters", "spacy", "none"],
+        filter_stopwords: Literal["reuters", "spacy", "none"],
         remove_punctuation=False,
         remove_whitespace=False,
     ):

--- a/sammo/runners.py
+++ b/sammo/runners.py
@@ -1,12 +1,13 @@
+from abc import abstractmethod
 import asyncio
+from collections.abc import MutableMapping
 import json
 import logging
 import os
 import pathlib
-import typing
-from abc import abstractmethod
-from collections.abc import MutableMapping
+
 from beartype import beartype
+from beartype.typing import Literal
 import openai
 
 from sammo import PROMPT_LOGGER_NAME
@@ -63,7 +64,7 @@ class OpenAIBaseRunner(Runner):
         model_id: str,
         api_config: dict | pathlib.Path,
         cache: None | MutableMapping | str | os.PathLike = None,
-        equivalence_class: str | typing.Literal["major", "exact"] = "major",
+        equivalence_class: str | Literal["major", "exact"] = "major",
         rate_limit: AtMost | list[AtMost] | Throttler | int = 2,
         max_retries: int = 50,
         max_context_window: int | None = None,

--- a/sammo/runners.py
+++ b/sammo/runners.py
@@ -76,8 +76,8 @@ class OpenAIBaseRunner(Runner):
         if isinstance(api_config, dict):
             self._oai_config = dict(api_config)
         elif isinstance(api_config, pathlib.Path):
-            self._oai_config = json.load(api_config.open())
-
+            with api_config.open() as api_config_file:
+                self._oai_config = json.load(api_config_file)
         if isinstance(rate_limit, Throttler):
             self._throttler = rate_limit
         elif isinstance(rate_limit, AtMost):

--- a/sammo/search.py
+++ b/sammo/search.py
@@ -3,14 +3,14 @@ import collections
 import copy
 import logging
 import random
-import typing
 from collections.abc import Callable
 import datetime
 from pathlib import Path
-from typing import Literal
-import pyglove as pg
+
 from beartype import beartype
+from beartype.typing import Literal
 from orjson import orjson
+import pyglove as pg
 from tabulate import tabulate
 
 import sammo.base

--- a/sammo/search_op.py
+++ b/sammo/search_op.py
@@ -2,7 +2,7 @@
 This module contains a variety of search operators that can be used to define a discrete search space for `GridSearch`
 or define a set of initial candidates for other search algorithms.
 """
-from typing import Iterable, Any
+from beartype.typing import Iterable, Any
 from pyglove.core.hyper import OneOf, ManyOf
 
 __all__ = ["one_of", "many_of", "permutate", "optional"]

--- a/sammo/store.py
+++ b/sammo/store.py
@@ -2,16 +2,16 @@
 arbitrary JSON-serializable objects that get rendered to byte strings for indexing.
 Mainly used to cache LLM API calls, but can be used for other purposes as well.
 """
+from collections.abc import MutableMapping
+from contextlib import ExitStack
+from io import BytesIO
 import logging
 import os
 import threading
 import warnings
-from collections.abc import MutableMapping
-from contextlib import ExitStack
-from io import BytesIO
 from pathlib import Path
-from typing import Callable
 
+from beartype.typing import Callable
 import filelock
 import orjson
 

--- a/sammo/throttler.py
+++ b/sammo/throttler.py
@@ -6,15 +6,17 @@ to run the job. The jobs are run in order of priority, breaking ties with creati
 """
 import asyncio
 import bisect
+from collections import deque
+from dataclasses import dataclass, field
 import enum
 import logging
 import threading
 import time
-from collections import deque
-from dataclasses import dataclass, field
-from typing import Literal
-__all__ = ["Throttler", "AtMost"]
+
 from beartype import beartype
+from beartype.typing import Literal
+
+__all__ = ["Throttler", "AtMost"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
A collection of small fixes that arose as I began exploring the library

## List of Changes
- Moved DEFAULT_NAMES definition underneath the doc string comment so that comment attaches to DataFormatter class rather than DEFAULT_NAMES
- Use a context manager to avoid open file handle leak in OpenAIBaseRunner when loading api credentials
- Added entries to gitignore for pyenv version file and a virtualenv
- Change call to staticmethod from an instance handle to a class handle
- Changed access to staticmethods from instance handle to class handle
- switch all uses of the 'typing' builtin module to 'beartype.typing'. This resolves pep 585 deprecation warnings emitted by beartype https://beartype.readthedocs.io/en/latest/api_roar/#pep-585-deprecations
- Only truncate the representation of Result.value if its longer than 100 characters
