### PR TITLE
Publish package and docs from build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,11 @@ jobs:
         run: |
           pipx install  --python '${{ steps.setup-python.outputs.python-path }}' twine
           twine check --strict dist/*
-			- name: Store the distribution files
-				uses: actions/upload-artifact@v3
-				with:
-					name: python-package-distributions
-					path: dist/
+      - name: Store the distribution files
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Build documentation artifacts
         run: |
           poetry run poe build-docs
@@ -80,18 +80,18 @@ jobs:
       defaults:
         run:
           shell: bash
-			environment:
-				name: testpypi
-				url: https://test.pypi.org/p/sammo
-			permissions:
-				id-token: write  # IMPORTANT: mandatory for trusted publishing
-			steps:
-				- name: Download all the dists
-					uses: actions/download-artifact@v3
-					with:
-						name: python-package-distributions
-						path: dist/
-				- name: Publish distribution to TestPyPI
-					uses: pypa/gh-action-pypi-publish@release/v1
-  				with:
-	  				repository-url: https://test.pypi.org/legacy/
+      environment:
+        name: testpypi
+        url: https://test.pypi.org/p/sammo
+      permissions:
+        id-token: write  # IMPORTANT: mandatory for trusted publishing
+      steps:
+        - name: Download all the dists
+          uses: actions/download-artifact@v3
+          with:
+            name: python-package-distributions
+            path: dist/
+        - name: Publish distribution to TestPyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,35 +52,46 @@ jobs:
       - name: Run tests
         run: |
           poetry run poe test -v
-  build-and-upload-docs:
-    name: Build and Upload Docs
-    runs-on: ubuntu-latest
-    needs: build
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        id: setup-python
-        with:
-          python-version: "3.11"
-      - name: Setup pipx for build tool isolation
+      - name: Build wheel and sdist for distribution
         run: |
-          pip install --user pipx
-          pipx ensurepath
-      - name: Set up poetry and install dependencies
+          pipx install  --python '${{ steps.setup-python.outputs.python-path }}' build
+          pyproject-build
+      - name: Check distribution with twine
         run: |
-          pipx install --python '${{ steps.setup-python.outputs.python-path }}' poetry
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
-          poetry install --with dev
-      - name: Build docs
+          pipx install  --python '${{ steps.setup-python.outputs.python-path }}' twine
+          twine check --strict dist/*
+			- name: Store the distribution files
+				uses: actions/upload-artifact@v3
+				with:
+					name: python-package-distributions
+					path: dist/
+      - name: Build documentation artifacts
         run: |
           poetry run poe build-docs
-      - name: Upload docs
+      - name: Store the documentation artifacts
         uses: actions/upload-pages-artifact@v3
         with:
           path: _build_docs/_build/html
+
+    publish-testpypi:
+      name: Publish to Test PyPI
+      runs-on: ubuntu-latest
+      needs: build
+      defaults:
+        run:
+          shell: bash
+			environment:
+				name: testpypi
+				url: https://test.pypi.org/p/sammo
+			permissions:
+				id-token: write  # IMPORTANT: mandatory for trusted publishing
+			steps:
+				- name: Download all the dists
+					uses: actions/download-artifact@v3
+					with:
+						name: python-package-distributions
+						path: dist/
+				- name: Publish distribution to TestPyPI
+					uses: pypa/gh-action-pypi-publish@release/v1
+  				with:
+	  				repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,28 +94,6 @@ jobs:
           name: zipped-documentation
           path: _build_docs/dist/
 
-  release-publish-pages:
-    name: Publish Documentation Site
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event == 'release'
-    defaults:
-      run:
-        shell: bash
-
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
   release-publish-artifacts:
     name: Publish Artifacts
     runs-on: ubuntu-latest
@@ -145,7 +123,7 @@ jobs:
         with:
           name: zipped-documentation
           path: dist/
-      - name: Generate SHA256 files for each wheel
+      - name: Generate SHA256 checksums for all artifacts
         run: |
           sha256sum dist/*.whl > checksums.txt
           sha256sum dist/*.tar.gz >> checksums.txt
@@ -158,3 +136,25 @@ jobs:
           files: |
             dist/*
             checksums.txt
+
+  release-publish-pages:
+    name: Publish Documentation Site
+    runs-on: ubuntu-latest
+    needs: release-publish-artifacts
+    if: github.event == 'release'
+    defaults:
+      run:
+        shell: bash
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,12 @@ on:
   pull_request:
     branches:
       - main
-  workflow_call:
+  release:
+    types: [published]
 jobs:
   build:
     name: Build
+
     strategy:
       fail-fast: false
       matrix:
@@ -20,10 +22,13 @@ jobs:
           - macos-latest
         python:
           - "3.11"
+
     runs-on: ${{ matrix.os }}
+
     defaults:
       run:
         shell: bash
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -69,31 +74,85 @@ jobs:
       - name: Build documentation artifacts
         run: |
           poetry run poe build-docs
-      - name: Store the documentation artifacts
+          DOCS_VERSION=`poetry version -s`
+          mkdir _build_docs/dist
+          pushd _build_docs/_build/html
+          zip -r ../../dist/sammo-docs-$DOCS_VERSION.zip .
+          popd
+      - name: Store the documentation artifacts for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         if: matrix.os == 'ubuntu-latest'
         with:
           path: _build_docs/_build/html
+      - name: Store the zipped documentation
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          name: zipped-documentation
+          path: _build_docs/dist/
 
-  publish-testpypi:
-    name: Publish to Test PyPI
+  release-publish-pages:
+    name: Publish Documentation Site
     runs-on: ubuntu-latest
     needs: build
+    if: github.event == 'release'
     defaults:
       run:
         shell: bash
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/sammo
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  release-publish-artifacts:
+    name: Publish Artifacts
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event == 'release'
+    defaults:
+      run:
+        shell: bash
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sammo
+
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
+
     steps:
-      - name: Download all the dists
+      - name: Download the distribution artifacts
         uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution to TestPyPI
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download zipped documentation
+        uses: actions/download-artifact@v3
         with:
-          repository-url: https://test.pypi.org/legacy/
+          name: zipped-documentation
+          path: dist/
+      - name: Generate SHA256 files for each wheel
+        run: |
+          sha256sum dist/*.whl > checksums.txt
+          sha256sum dist/*.tar.gz >> checksums.txt
+          sha256sum dist/*.zip >> checksums.txt
+          cat checksums.txt
+      - name: Update release with SHA256 and Artifacts
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            dist/*
+            checksums.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,25 +73,25 @@ jobs:
         with:
           path: _build_docs/_build/html
 
-    publish-testpypi:
-      name: Publish to Test PyPI
-      runs-on: ubuntu-latest
-      needs: build
-      defaults:
-        run:
-          shell: bash
-      environment:
-        name: testpypi
-        url: https://test.pypi.org/p/sammo
-      permissions:
-        id-token: write  # IMPORTANT: mandatory for trusted publishing
-      steps:
-        - name: Download all the dists
-          uses: actions/download-artifact@v3
-          with:
-            name: python-package-distributions
-            path: dist/
-        - name: Publish distribution to TestPyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            repository-url: https://test.pypi.org/legacy/
+  publish-testpypi:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    defaults:
+      run:
+        shell: bash
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/sammo
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           twine check --strict dist/*
       - name: Store the distribution files
         uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: python-package-distributions
           path: dist/
@@ -70,6 +71,7 @@ jobs:
           poetry run poe build-docs
       - name: Store the documentation artifacts
         uses: actions/upload-pages-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           path: _build_docs/_build/html
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build documentation artifacts
         run: |
           poetry run poe build-docs
+      - name: Zip documentation
+        if: matrix.os == 'ubuntu-latest'
+        run: |
           DOCS_VERSION=`poetry version -s`
           mkdir _build_docs/dist
           pushd _build_docs/_build/html


### PR DESCRIPTION
This PR adds artifact and document publication to the build pipeline. Publishing is only triggered on release, and will be skipped otherwise. 