### PR TITLE
Support for multiple matches

### DIFF
--- a/sammo/base.py
+++ b/sammo/base.py
@@ -315,8 +315,8 @@ class Component:
 
         :param regex_or_query: A regex string or a query dict or a CompiledQuery object.
         :param return_path: Whether to return a tuple of (path, value) or just the value.
-        :param max_matches: The maximum number of matches to return.
-        :return: Either component, tuple of (path, component) or None if no match was found.
+        :param max_matches: The maximum number of matches to return. None returns everything.
+        :return: Either component, tuple of (path, component) or None if no match was found. List if max_matches > 1.
         """
         compiled_query = CompiledQuery.from_path(regex_or_query)
         matches = list(pg.query(self, **compiled_query.query).items())
@@ -333,10 +333,9 @@ class Component:
 
         if not matches:
             return None
-        elif return_path:
-            return matches[0]
         else:
-            return matches[0][1]
+            projected = matches if return_path else [m[1] for m in matches]
+            return projected[0] if max_matches == 1 else projected
 
     def replace_static_text(self, regex_or_query: str | dict | CompiledQuery, new_text: str):
         me = pg.clone(self)

--- a/sammo/base_test.py
+++ b/sammo/base_test.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from sammo.base import Template, VerbatimText
+
+
+def test_simple_query():
+    a = VerbatimText("Hello", name="1")
+    b = VerbatimText("World", name="2")
+    nested = Template("{{a}} {{b}}", a=a, b=b)
+    assert nested.query({"name": "1"}) == a
+    assert nested.query({"name": "2"}) == b
+    assert nested.query({"name": "3"}) is None
+
+
+def test_same_name_query():
+    a = VerbatimText("Hello", name="1")
+    b = VerbatimText("World", name="1")
+    nested = Template("{{a}} {{b}}", a=a, b=b)
+    assert nested.query({"name": "1"}) == a
+    assert nested.query({"name": "2"}) is None
+    assert nested.query({"name": "1"}, max_matches=None) == [a, b]
+    assert nested.query({"name": "1"}, return_path=True) == ("a", a)
+    assert nested.query({"name": "1"}, max_matches=None, return_path=True) == [("a", a), ("b", b)]

--- a/sammo/mutators.py
+++ b/sammo/mutators.py
@@ -372,12 +372,13 @@ class ShortenSegment(Mutator):
     async def mutate(
         self, candidate: Output, data: DataTable, runner: Runner, n_mutations: int = 1, random_state: int = 42
     ) -> list[MutatedCandidate]:
-        segment_path, segment_content = candidate.query(self._path_descriptor, return_path=True)
-        segment_path += ".content"
+        segments = candidate.query(self._path_descriptor, return_path=True, max_matches=None)
+        segment_content = segments[0][1]
+        segment_paths = [s[0] + ".content" for s in segments]
         segment_content = segment_content.static_text()
         rewritten = await self._rewrite(runner, segment_content, n_mutations, random_state)
         return [
-            MutatedCandidate(self.__class__.__name__, pg.clone(candidate, override={segment_path: r}))
+            MutatedCandidate(self.__class__.__name__, pg.clone(candidate, override={p: r for p in segment_paths}))
             for r in rewritten
         ]
 


### PR DESCRIPTION
- added test for Component.query()
- fixed bug in query() where not all matches were returned despite max_matches > 1
- paraphrasing-based mutators now change all components that get returned by a query